### PR TITLE
feat: mobile site search for navbar #1559

### DIFF
--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -30,13 +30,16 @@
 }
 
 .nav-button {
-  &:hover {
-    background: variables.$blue-50 !important;
-  }
+  @include breakpoints.media-breakpoint-up(lg) {
+    &:hover {
+      /* stylelint-disable-next-line declaration-no-important */
+      background: variables.$blue-50 !important;
+    }
 
-  &:focus,
-  &.focus {
-    border-color: variables.$blue-500;
+    &:focus,
+    &.focus {
+      border-color: variables.$blue-500;
+    }
   }
 }
 
@@ -181,16 +184,26 @@ $nav-hover-delay: 300ms;
     font-size: variables.$font-size-75;
 
     // shadow for additional visual separation between nav and more plain pages
-    filter: drop-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
-    box-shadow: none;
+    @include breakpoints.media-breakpoint-up(lg) {
+      filter: drop-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
+      box-shadow: none;
+    }
   }
 
   .nav-es-global {
     // add a background so veil goes under the nav and nav stands out against page bg
     background-color: variables.$white;
 
-    // shadow for additional visual separation between nav and more plain pages
-    box-shadow: 0 4px 4px rgba(221, 221, 221, 0.25);
+    @include breakpoints.media-breakpoint-up(lg) {
+      // shadow for additional visual separation between nav and more plain pages
+      box-shadow: 0 4px 4px rgba(221, 221, 221, 0.25);
+    }
+  }
+
+  .nav-search-bar-mobile {
+    z-index: 1000;
+    font-size: variables.$font-size-75;
+    background-color: variables.$white;
   }
 
   // override es-ds default

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -204,6 +204,20 @@ $nav-hover-delay: 300ms;
     z-index: 1000;
     font-size: variables.$font-size-75;
     background-color: variables.$white;
+
+    .input-wrapper {
+      width: 100% !important;
+    }
+
+    .btn-primary {
+      display: none !important;
+    }
+
+    .nav-search-close-mobile {
+      @include breakpoints.media-breakpoint-up(lg) {
+        position: absolute;
+      }
+    }
   }
 
   // override es-ds default

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -175,8 +175,14 @@ $nav-hover-delay: 300ms;
 .nav-es-container {
   .nav-es-global,
   .nav-es-sticky {
+    // pull navbar up to avoid overlay from getting covered by other DOM elements
+    z-index: 1000;
     // default should be size 14px according to figma
     font-size: variables.$font-size-75;
+
+    // shadow for additional visual separation between nav and more plain pages
+    filter: drop-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
+    box-shadow: none;
   }
 
   .nav-es-global {
@@ -274,7 +280,8 @@ $nav-hover-delay: 300ms;
     }
   }
 
-  .account-icon, .search-icon {
+  .account-icon,
+  .search-icon {
     fill: variables.$blue-900;
   }
 
@@ -284,16 +291,6 @@ $nav-hover-delay: 300ms;
 
   // On Desktop a hovers display the dropdowns
   @media only screen and (min-width: $desktop-min-width) {
-    .nav-es-global,
-    .nav-es-sticky {
-      // pull navbar up to avoid overlay from getting covered by other DOM elements
-      z-index: 1000;
-
-      // shadow for additional visual separation between nav and more plain pages
-      filter: drop-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
-      box-shadow: none;
-    }
-
     // sticky nav bar, initially positioned out of viewport
     .nav-es-sticky {
       top: 0;

--- a/es-design-system/pages/molecules/es-search-bar.vue
+++ b/es-design-system/pages/molecules/es-search-bar.vue
@@ -1,11 +1,17 @@
 <template>
     <div>
-        <h1 class="mb-500">Search bar</h1>
-        <h2>Basic example</h2>
+        <h1 class="mb-500">
+            Search bar
+        </h1>
+        <h2>
+            Basic example
+        </h2>
         <es-search-bar
             id="searchBar1"
             class="my-500" />
-        <h2>Example with open/close functionality</h2>
+        <h2>
+            Example with open/close functionality
+        </h2>
         <es-search-bar
             v-if="showSearchBar"
             id="searchBar2"
@@ -36,14 +42,18 @@
         </es-button>
 
         <div class="my-500">
-            <h2>EsSearchBar slots</h2>
+            <h2>
+                EsSearchBar slots
+            </h2>
             <ds-prop-table
                 :rows="slotTableRows"
                 :widths="slotTableWidths" />
         </div>
 
         <div class="my-500">
-            <h2>EsSearchBar props</h2>
+            <h2>
+                EsSearchBar props
+            </h2>
             <ds-prop-table
                 :rows="propTableRows"
                 :widths="propTableWidths" />
@@ -66,8 +76,16 @@ export default {
             docCode: '',
             showSearchBar: false,
             propTableRows: [
-                ['buttonText', 'Search', 'Text to display on the submit button.'],
-                ['placeholder', 'Try "best solar panels"', 'Placeholder text to display in the search input.'],
+                [
+                    'buttonText',
+                    'Search',
+                    'Text to display on the submit button.',
+                ],
+                [
+                    'placeholder',
+                    'Try "best solar panels"',
+                    'Placeholder text to display in the search input.',
+                ],
             ],
             propTableWidths: {
                 md: ['4', '2', '6'],

--- a/es-design-system/pages/molecules/es-search-bar.vue
+++ b/es-design-system/pages/molecules/es-search-bar.vue
@@ -1,17 +1,14 @@
 <template>
     <div>
-        <h1 class="mb-500">
-            Search bar
-        </h1>
-        <h2>
-            Basic example
-        </h2>
-        <es-search-bar class="my-500" />
-        <h2>
-            Example with open/close functionality
-        </h2>
+        <h1 class="mb-500">Search bar</h1>
+        <h2>Basic example</h2>
+        <es-search-bar
+            id="searchBar1"
+            class="my-500" />
+        <h2>Example with open/close functionality</h2>
         <es-search-bar
             v-if="showSearchBar"
+            id="searchBar2"
             class="my-500">
             <template #close>
                 <es-button

--- a/es-design-system/pages/molecules/es-search-bar.vue
+++ b/es-design-system/pages/molecules/es-search-bar.vue
@@ -36,18 +36,14 @@
         </es-button>
 
         <div class="my-500">
-            <h2>
-                EsSearchBar slots
-            </h2>
+            <h2>EsSearchBar slots</h2>
             <ds-prop-table
                 :rows="slotTableRows"
                 :widths="slotTableWidths" />
         </div>
 
         <div class="my-500">
-            <h2>
-                EsSearchBar props
-            </h2>
+            <h2>EsSearchBar props</h2>
             <ds-prop-table
                 :rows="propTableRows"
                 :widths="propTableWidths" />
@@ -70,16 +66,8 @@ export default {
             docCode: '',
             showSearchBar: false,
             propTableRows: [
-                [
-                    'buttonText',
-                    'Search',
-                    'Text to display on the submit button.',
-                ],
-                [
-                    'placeholder',
-                    'Try "best solar panels"',
-                    'Placeholder text to display in the search input.',
-                ],
+                ['buttonText', 'Search', 'Text to display on the submit button.'],
+                ['placeholder', 'Try "best solar panels"', 'Placeholder text to display in the search input.'],
             ],
             propTableWidths: {
                 md: ['4', '2', '6'],
@@ -100,7 +88,7 @@ export default {
     },
     async created() {
         if (this.$prism) {
-        /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+            /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
             const docSource = await import('!raw-loader!./es-search-bar.vue');
             const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsSearchBar.vue');
             /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */

--- a/es-design-system/pages/organisms/es-nav-bar.vue
+++ b/es-design-system/pages/organisms/es-nav-bar.vue
@@ -4,8 +4,7 @@
             EsNavBar
         </h1>
         <p>
-            The nav bar is a specialized component intended for use outside the normal content
-            container. See above.
+            The nav bar is a specialized component intended for use outside the normal content container. See above.
         </p>
 
         <p
@@ -57,7 +56,7 @@ export default {
     },
     async created() {
         if (this.$prism) {
-        /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+            /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
             const docSource = await import('!raw-loader!./es-nav-bar.vue');
             const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsNavBar.vue');
             /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -141,7 +141,7 @@
                     </b-container>
                     <!-- desktop search bar -->
                     <b-container
-                        class="nav-search-bar"
+                        class="nav-search-bar-desktop"
                         style="display: none">
                         <div class="row w-100">
                             <es-search-bar id="searchBarDesktop">
@@ -334,16 +334,16 @@ export default {
         const overlay = document.querySelector('.content-overlay');
 
         // Search bar elements for hiding/showing
-        const searchBar = document.querySelector('.nav-search-bar');
+        const searchBarDesktop = document.querySelector('.nav-search-bar-desktop');
         const searchBarMobile = document.querySelector('.nav-search-bar-mobile');
         const productMenu = document.querySelector('.product-menu');
         const searchIconMobile = document.querySelector('.search-icon-mobile');
         const searchIconDesktop = document.querySelector('.search-icon-desktop');
-        const searchForm = document.getElementById('searchBar');
+        const searchForm = document.getElementById('searchBarDesktop');
 
         // Function to show/hide search bar
         function toggle_search_bar(show_search_bar) {
-            searchBar.style.display = show_search_bar ? 'flex' : 'none';
+            searchBarDesktop.style.display = show_search_bar ? 'flex' : 'none';
             searchBarMobile.style.display = show_search_bar ? 'flex' : 'none';
             productMenu.style.display = show_search_bar ? 'none' : 'flex';
             if (show_search_bar) {
@@ -361,7 +361,7 @@ export default {
             if (overlay_visible) {
                 overlay.classList.add('show');
             } else if (!overlay_visible
-                && searchBar.style.display === 'none' && searchBarMobile.style.display === 'none') {
+                && searchBarDesktop.style.display === 'none' && searchBarMobile.style.display === 'none') {
                 overlay.classList.remove('show');
             }
         }
@@ -386,7 +386,8 @@ export default {
 
         // Collapse all open menus on window resize
         window.addEventListener('resize', () => {
-            if (mainMenuCheckbox.checked || accountMenuCheckbox.checked || searchBar.style.display !== 'none') {
+            if (mainMenuCheckbox.checked || accountMenuCheckbox.checked
+                || searchBarDesktop.style.display !== 'none' || searchBarMobile.style.display !== 'none') {
                 collapse_mobile_menus();
             }
         });
@@ -420,7 +421,7 @@ export default {
 
         // Show overlay on click for desktop
         document.querySelector('.search-toggle-desktop').addEventListener('click', () => {
-            const show = searchBar.style.display === 'none';
+            const show = searchBarDesktop.style.display === 'none';
             toggle_search_bar(show);
             show_overlay(show);
         });

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -241,20 +241,22 @@
             </div>
         </nav>
         <!-- mobile search bar -->
-        <b-container
-            class="nav-search-bar-mobile d-lg-none"
+        <div
+            class="nav-search-bar-mobile d-lg-none position-relative"
             style="display: none">
-            <es-search-bar>
-                <template #close>
-                    <es-button
-                        class="order-1 d-flex d-lg-none align-self-end nav-button nav-search-close-mobile p-0"
-                        aria-label="Close search bar"
-                        variant="link">
-                        <icon-x />
-                    </es-button>
-                </template>
-            </es-search-bar>
-        </b-container>
+            <b-container>
+                <es-search-bar>
+                    <template #close>
+                        <es-button
+                            class="order-1 d-flex d-lg-none align-self-end nav-button nav-search-close-mobile p-0"
+                            aria-label="Close search bar"
+                            variant="link">
+                            <icon-x />
+                        </es-button>
+                    </template>
+                </es-search-bar>
+            </b-container>
+        </div>
         <!-- sticky nav bar -->
         <nav class="nav-es-sticky bg-white d-none d-lg-block position-fixed py-25">
             <b-container class="align-items-center d-flex justify-content-between">

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -141,7 +141,7 @@
                             <es-search-bar>
                                 <template #close>
                                     <es-button
-                                        class="position-absolute nav-button mb-3 nav-search-close"
+                                        class="position-absolute nav-button mb-100 nav-search-close"
                                         aria-label="Close search bar"
                                         style="right: 0"
                                         variant="link">
@@ -242,21 +242,18 @@
         </nav>
         <!-- mobile search bar -->
         <b-container
-            class="nav-search-bar-mobile d-lg-none pt-100"
+            class="nav-search-bar-mobile d-lg-none"
             style="display: none">
-            <div class="row w-100">
-                <es-search-bar>
-                    <template #close>
-                        <es-button
-                            class="position-absolute nav-button mb-3 nav-search-close-mobile d-lg-none"
-                            aria-label="Close search bar"
-                            style="right: 0"
-                            variant="link">
-                            <icon-x />
-                        </es-button>
-                    </template>
-                </es-search-bar>
-            </div>
+            <es-search-bar>
+                <template #close>
+                    <es-button
+                        class="order-1 d-flex d-lg-none align-self-end nav-button nav-search-close-mobile p-0"
+                        aria-label="Close search bar"
+                        variant="link">
+                        <icon-x />
+                    </es-button>
+                </template>
+            </es-search-bar>
         </b-container>
         <!-- sticky nav bar -->
         <nav class="nav-es-sticky bg-white d-none d-lg-block position-fixed py-25">

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -138,7 +138,7 @@
                         class="nav-search-bar"
                         style="display: none">
                         <div class="row w-100">
-                            <es-search-bar>
+                            <es-search-bar id="searchBarDesktop">
                                 <template #close>
                                     <es-button
                                         class="position-absolute nav-button mb-100 nav-search-close"
@@ -245,7 +245,7 @@
             class="nav-search-bar-mobile d-lg-none position-relative"
             style="display: none">
             <b-container>
-                <es-search-bar>
+                <es-search-bar id="searchBarMobile">
                     <template #close>
                         <es-button
                             class="order-1 d-flex d-lg-none align-self-end nav-button nav-search-close-mobile p-0"

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -340,7 +340,8 @@ export default {
         const productMenu = document.querySelector('.product-menu');
         const searchIconMobile = document.querySelector('.search-icon-mobile');
         const searchIconDesktop = document.querySelector('.search-icon-desktop');
-        const searchForm = document.getElementById('searchBarDesktop');
+        const searchFormMobile = document.getElementById('searchBarMobile');
+        const searchFormDesktop = document.getElementById('searchBarDesktop');
 
         // Function to show/hide search bar
         function toggle_search_bar(show_search_bar) {
@@ -350,7 +351,12 @@ export default {
             if (show_search_bar) {
                 searchIconMobile.classList.add('search-open');
                 searchIconDesktop.classList.add('search-open');
-                searchForm.focus();
+
+                if (searchFormMobile.checkVisibility()) {
+                    searchFormMobile.focus();
+                } else {
+                    searchFormDesktop.focus();
+                }
             } else {
                 searchIconMobile.classList.remove('search-open');
                 searchIconDesktop.classList.remove('search-open');

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -31,7 +31,8 @@
                 <!-- mobile search icon -->
                 <div
                     id="navBarSearchIconMobile"
-                    class="d-block d-lg-none">
+                    class="d-lg-none"
+                    :class="showSearch ? 'd-block' : 'd-none'">
                     <es-button
                         variant="link"
                         aria-label="Open search bar"
@@ -114,6 +115,7 @@
                                 <slot name="logo" />
                             </template>
                         </es-nav-bar-top-level-menu>
+                        <!-- desktop search icon -->
                         <div
                             id="navBarSearchIcon"
                             class="nav-item d-none pt-100"

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -53,7 +53,7 @@
                     </label>
                 </div>
             </div>
-
+            <!-- eslint-disable-next-line vue/html-self-closing -->
             <input
                 id="data--main-menu"
                 class="menu-checkbox main-menu-checkbox"
@@ -240,6 +240,24 @@
                 </ul>
             </div>
         </nav>
+        <!-- mobile search bar -->
+        <b-container
+            class="nav-search-bar-mobile d-lg-none pt-100"
+            style="display: none">
+            <div class="row w-100">
+                <es-search-bar>
+                    <template #close>
+                        <es-button
+                            class="position-absolute nav-button mb-3 nav-search-close-mobile d-lg-none"
+                            aria-label="Close search bar"
+                            style="right: 0"
+                            variant="link">
+                            <icon-x />
+                        </es-button>
+                    </template>
+                </es-search-bar>
+            </div>
+        </b-container>
         <!-- sticky nav bar -->
         <nav class="nav-es-sticky bg-white d-none d-lg-block position-fixed py-25">
             <b-container class="align-items-center d-flex justify-content-between">
@@ -308,6 +326,7 @@ export default {
 
         // Search bar elements for hiding/showing
         const searchBar = document.querySelector('.nav-search-bar');
+        const searchBarMobile = document.querySelector('.nav-search-bar-mobile');
         const productMenu = document.querySelector('.product-menu');
         const searchIconMobile = document.querySelector('.search-icon-mobile');
         const searchIconDesktop = document.querySelector('.search-icon-desktop');
@@ -316,6 +335,7 @@ export default {
         // Function to show/hide search bar
         function toggle_search_bar(show_search_bar) {
             searchBar.style.display = show_search_bar ? 'flex' : 'none';
+            searchBarMobile.style.display = show_search_bar ? 'flex' : 'none';
             productMenu.style.display = show_search_bar ? 'none' : 'flex';
             if (show_search_bar) {
                 searchIconMobile.classList.add('search-open');
@@ -331,7 +351,8 @@ export default {
         function show_overlay(overlay_visible) {
             if (overlay_visible) {
                 overlay.classList.add('show');
-            } else if (!overlay_visible && searchBar.style.display === 'none') {
+            } else if (!overlay_visible
+                && searchBar.style.display === 'none' && searchBarMobile.style.display === 'none') {
                 overlay.classList.remove('show');
             }
         }
@@ -383,7 +404,7 @@ export default {
 
         // Show overlay on click for mobile
         document.querySelector('.search-toggle-mobile').addEventListener('click', () => {
-            const show = searchBar.style.display === 'none';
+            const show = searchBarMobile.style.display === 'none';
             toggle_search_bar(show);
             show_overlay(show);
         });
@@ -396,6 +417,11 @@ export default {
         });
 
         document.querySelector('.nav-search-close').addEventListener('click', () => {
+            toggle_search_bar(false);
+            show_overlay(false);
+        });
+
+        document.querySelector('.nav-search-close-mobile').addEventListener('click', () => {
             toggle_search_bar(false);
             show_overlay(false);
         });

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -147,7 +147,7 @@
                             <es-search-bar id="searchBarDesktop">
                                 <template #close>
                                     <es-button
-                                        class="position-absolute nav-button mb-100 nav-search-close"
+                                        class="position-absolute nav-button mb-100 nav-search-close-desktop"
                                         aria-label="Close search bar"
                                         style="right: 0"
                                         variant="link">
@@ -335,27 +335,29 @@ export default {
         const overlay = document.querySelector('.content-overlay');
 
         // Search bar elements for hiding/showing
-        const searchBarDesktop = document.querySelector('.nav-search-bar-desktop');
-        const searchBarMobile = document.querySelector('.nav-search-bar-mobile');
-        const productMenu = document.querySelector('.product-menu');
         const searchIconMobile = document.querySelector('.search-icon-mobile');
         const searchIconDesktop = document.querySelector('.search-icon-desktop');
-        const searchFormMobile = document.getElementById('searchBarMobile');
-        const searchFormDesktop = document.getElementById('searchBarDesktop');
+        const productMenu = document.querySelector('.product-menu');
+
+        const navSearchBarMobile = document.querySelector('.nav-search-bar-mobile');
+        const navSearchBarDesktop = document.querySelector('.nav-search-bar-desktop');
+        const searchBarMobile = document.getElementById('searchBarMobile');
+        const searchBarDesktop = document.getElementById('searchBarDesktop');
 
         // Function to show/hide search bar
         function toggle_search_bar(show_search_bar) {
-            searchBarDesktop.style.display = show_search_bar ? 'flex' : 'none';
-            searchBarMobile.style.display = show_search_bar ? 'flex' : 'none';
+            navSearchBarMobile.style.display = show_search_bar ? 'flex' : 'none';
+            navSearchBarDesktop.style.display = show_search_bar ? 'flex' : 'none';
             productMenu.style.display = show_search_bar ? 'none' : 'flex';
+
             if (show_search_bar) {
                 searchIconMobile.classList.add('search-open');
                 searchIconDesktop.classList.add('search-open');
 
-                if (searchFormMobile.checkVisibility()) {
-                    searchFormMobile.focus();
+                if (searchBarMobile.checkVisibility()) {
+                    searchBarMobile.focus();
                 } else {
-                    searchFormDesktop.focus();
+                    searchBarDesktop.focus();
                 }
             } else {
                 searchIconMobile.classList.remove('search-open');
@@ -368,7 +370,7 @@ export default {
             if (overlay_visible) {
                 overlay.classList.add('show');
             } else if (!overlay_visible
-                && searchBarDesktop.style.display === 'none' && searchBarMobile.style.display === 'none') {
+                && navSearchBarMobile.style.display === 'none' && navSearchBarDesktop.style.display === 'none') {
                 overlay.classList.remove('show');
             }
         }
@@ -394,7 +396,7 @@ export default {
         // Collapse all open menus on window resize
         window.addEventListener('resize', () => {
             if (mainMenuCheckbox.checked || accountMenuCheckbox.checked
-                || searchBarDesktop.style.display !== 'none' || searchBarMobile.style.display !== 'none') {
+                || navSearchBarMobile.style.display !== 'none' || navSearchBarDesktop.style.display !== 'none') {
                 collapse_mobile_menus();
             }
         });
@@ -419,26 +421,26 @@ export default {
                 });
             });
 
-        // Show overlay on click for mobile
+        // Click handlers for navbar search buttons
         document.querySelector('.search-toggle-mobile').addEventListener('click', () => {
-            const show = searchBarMobile.style.display === 'none';
+            const show = navSearchBarMobile.style.display === 'none';
             toggle_search_bar(show);
             show_overlay(show);
         });
 
-        // Show overlay on click for desktop
         document.querySelector('.search-toggle-desktop').addEventListener('click', () => {
-            const show = searchBarDesktop.style.display === 'none';
+            const show = navSearchBarDesktop.style.display === 'none';
             toggle_search_bar(show);
             show_overlay(show);
         });
 
-        document.querySelector('.nav-search-close').addEventListener('click', () => {
+        // Click handlers for search form close buttons
+        document.querySelector('.nav-search-close-mobile').addEventListener('click', () => {
             toggle_search_bar(false);
             show_overlay(false);
         });
 
-        document.querySelector('.nav-search-close-mobile').addEventListener('click', () => {
+        document.querySelector('.nav-search-close-desktop').addEventListener('click', () => {
             toggle_search_bar(false);
             show_overlay(false);
         });

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -417,6 +417,7 @@ export default {
             .forEach((element) => {
                 element.addEventListener('mouseover', () => {
                     show_overlay(true);
+                    toggle_search_bar_desktop(false);
                 });
                 element.addEventListener('mouseout', () => {
                 // Hide overlay on mouseout on desktop not mobile
@@ -452,6 +453,7 @@ export default {
         mainMenuCheckbox.addEventListener('change', (event) => {
             if (event.target.checked) {
                 show_mobile_menus();
+                toggle_search_bar_mobile(false);
             } else {
                 collapse_mobile_menus();
             }
@@ -461,6 +463,7 @@ export default {
         accountMenuCheckbox.addEventListener('change', (event) => {
             if (event.target.checked) {
                 show_mobile_menus();
+                toggle_search_bar_mobile(false);
             } else {
                 collapse_mobile_menus();
             }

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -116,9 +116,13 @@
                         </es-nav-bar-top-level-menu>
                         <div
                             id="navBarSearchIcon"
-                            class="nav-item d-none d-lg-block pt-100">
+                            class="nav-item d-none pt-100"
+                            :class="{
+                                'd-lg-block': showSearch,
+                            }">
                             <es-button
-                                variant="link"
+                                variant="
+                            link"
                                 aria-label="Open search bar"
                                 class="nav-button nav-link search-toggle-desktop d-none d-lg-flex flex-nowrap py-100">
                                 <icon-search
@@ -307,6 +311,10 @@ export default {
         globalContent: {
             type: Object,
             required: true,
+        },
+        showSearch: {
+            type: Boolean,
+            default: false,
         },
     },
     mounted() {

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -3,7 +3,8 @@
         id="nav-main"
         class="nav-es-container">
         <div class="content-overlay" />
-        <nav class="nav-es-global navbar navbar-expand navbar-light py-0 font-size-base">
+        <nav
+            class="nav-es-global navbar navbar-expand navbar-light py-0 font-size-base">
             <!-- mobile hamburger menu button -->
             <div class="d-flex d-lg-none col-3 px-0">
                 <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
@@ -59,7 +60,7 @@
                 id="data--main-menu"
                 class="menu-checkbox main-menu-checkbox"
                 aria-labelledby="data--main-menu"
-                type="checkbox" />
+                type="checkbox">
             <!-- first-level menu on mobile, the whole nav on desktop-->
             <div
                 id="navbarNavDropdown"
@@ -123,8 +124,7 @@
                                 'd-lg-block': showSearch,
                             }">
                             <es-button
-                                variant="
-                            link"
+                                variant="link"
                                 aria-label="Open search bar"
                                 class="nav-button nav-link search-toggle-desktop d-none d-lg-flex flex-nowrap py-100">
                                 <icon-search
@@ -158,7 +158,8 @@
                         </div>
                     </b-container>
                     <!-- mobile+desktop product menus -->
-                    <b-container class="flex-lg-nowrap justify-content-lg-end product-menu">
+                    <b-container
+                        class="flex-lg-nowrap justify-content-lg-end product-menu">
                         <div class="row">
                             <es-nav-bar-product-menu
                                 v-for="product in globalContent.products"
@@ -187,7 +188,7 @@
                 id="data--account-menu"
                 class="menu-checkbox account-menu-checkbox"
                 aria-labelledby="data--account-menu"
-                type="checkbox" />
+                type="checkbox">
             <!-- mobile account menu -->
             <div class="menu top-level-menu align-items-start d-flex d-lg-none flex-grow-1">
                 <!-- menu header -->

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -3,10 +3,9 @@
         id="nav-main"
         class="nav-es-container">
         <div class="content-overlay" />
-        <nav
-            class="nav-es-global navbar navbar-expand navbar-light py-0 font-size-base">
+        <nav class="nav-es-global navbar navbar-expand navbar-light py-0 font-size-base">
             <!-- mobile hamburger menu button -->
-            <div class="d-flex d-lg-none col-2 px-0">
+            <div class="d-flex d-lg-none col-3 px-0">
                 <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
                 <label
                     for="data--main-menu"
@@ -19,7 +18,7 @@
             </div>
             <!-- mobile logo -->
             <es-nav-bar-link
-                class="d-flex d-lg-none col-8 align-self-center justify-content-center px-0"
+                class="d-flex d-lg-none col-6 align-self-center justify-content-center px-0"
                 :href="globalContent.home.link">
                 <div class="nav-es-logo-mobile align-items-center d-flex">
                     <slot name="logo" />
@@ -28,23 +27,38 @@
                     {{ globalContent.home.name }}
                 </span>
             </es-nav-bar-link>
-            <!-- mobile account menu trigger -->
-            <div class="d-flex d-lg-none justify-content-end col-2 px-0">
-                <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-                <label
-                    class="mb-0 text-decoration-none"
-                    for="data--account-menu">
-                    <icon-person class="align-self-center account-icon" />
-                    <span class="sr-only">
-                        {{ accountContent.mobileAccountButtonAltText }}
-                    </span>
-                </label>
+            <div class="col-3 d-flex flex-nowrap d-lg-none justify-content-end px-0">
+                <!-- mobile search icon -->
+                <div
+                    id="navBarSearchIconMobile"
+                    class="d-block d-lg-none">
+                    <es-button
+                        variant="link"
+                        aria-label="Open search bar"
+                        class="nav-button nav-link search-toggle-mobile d-flex flex-nowrap d-lg-none py-0 px-50 mr-100">
+                        <icon-search class="align-self-center search-icon-mobile" />
+                    </es-button>
+                </div>
+
+                <!-- mobile account menu trigger -->
+                <div class="d-flex d-lg-none align-self-center">
+                    <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+                    <label
+                        class="mb-0 text-decoration-none"
+                        for="data--account-menu">
+                        <icon-person class="align-self-center account-icon" />
+                        <span class="sr-only">
+                            {{ accountContent.mobileAccountButtonAltText }}
+                        </span>
+                    </label>
+                </div>
             </div>
+
             <input
                 id="data--main-menu"
                 class="menu-checkbox main-menu-checkbox"
                 aria-labelledby="data--main-menu"
-                type="checkbox">
+                type="checkbox" />
             <!-- first-level menu on mobile, the whole nav on desktop-->
             <div
                 id="navbarNavDropdown"
@@ -102,16 +116,13 @@
                         </es-nav-bar-top-level-menu>
                         <div
                             id="navBarSearchIcon"
-                            class="nav-item d-none pt-100"
-                            :class="{
-                                'd-lg-block': showSearch,
-                            }">
+                            class="nav-item d-none d-lg-block pt-100">
                             <es-button
                                 variant="link"
                                 aria-label="Open search bar"
-                                class="nav-button nav-link icon-toggle d-none d-lg-flex flex-nowrap py-100">
+                                class="nav-button nav-link search-toggle-desktop d-none d-lg-flex flex-nowrap py-100">
                                 <icon-search
-                                    class="align-self-center search-icon"
+                                    class="align-self-center search-icon-desktop"
                                     width="20px !important"
                                     height="20px !important" />
                             </es-button>
@@ -122,7 +133,7 @@
                             class="d-none d-lg-block pt-100"
                             :logged-out="accountContent.loggedOut" />
                     </b-container>
-                    <!-- mobile+desktop product menus -->
+                    <!-- desktop search bar -->
                     <b-container
                         class="nav-search-bar"
                         style="display: none">
@@ -140,8 +151,8 @@
                             </es-search-bar>
                         </div>
                     </b-container>
-                    <b-container
-                        class="flex-lg-nowrap justify-content-lg-end product-menu">
+                    <!-- mobile+desktop product menus -->
+                    <b-container class="flex-lg-nowrap justify-content-lg-end product-menu">
                         <div class="row">
                             <es-nav-bar-product-menu
                                 v-for="product in globalContent.products"
@@ -170,7 +181,7 @@
                 id="data--account-menu"
                 class="menu-checkbox account-menu-checkbox"
                 aria-labelledby="data--account-menu"
-                type="checkbox">
+                type="checkbox" />
             <!-- mobile account menu -->
             <div class="menu top-level-menu align-items-start d-flex d-lg-none flex-grow-1">
                 <!-- menu header -->
@@ -280,10 +291,6 @@ export default {
             type: Object,
             required: true,
         },
-        showSearch: {
-            type: Boolean,
-            default: false,
-        },
     },
     mounted() {
         // CUSTOM GLOBAL-NAV SCRIPT STARTS
@@ -302,7 +309,8 @@ export default {
         // Search bar elements for hiding/showing
         const searchBar = document.querySelector('.nav-search-bar');
         const productMenu = document.querySelector('.product-menu');
-        const searchIcon = document.querySelector('.search-icon');
+        const searchIconMobile = document.querySelector('.search-icon-mobile');
+        const searchIconDesktop = document.querySelector('.search-icon-desktop');
         const searchForm = document.getElementById('searchBar');
 
         // Function to show/hide search bar
@@ -310,10 +318,12 @@ export default {
             searchBar.style.display = show_search_bar ? 'flex' : 'none';
             productMenu.style.display = show_search_bar ? 'none' : 'flex';
             if (show_search_bar) {
-                searchIcon.classList.add('search-open');
+                searchIconMobile.classList.add('search-open');
+                searchIconDesktop.classList.add('search-open');
                 searchForm.focus();
             } else {
-                searchIcon.classList.remove('search-open');
+                searchIconMobile.classList.remove('search-open');
+                searchIconDesktop.classList.remove('search-open');
             }
         }
 
@@ -371,8 +381,15 @@ export default {
                 });
             });
 
-        // Show overlay on click for desktop only
-        document.querySelector('.icon-toggle').addEventListener('click', () => {
+        // Show overlay on click for mobile
+        document.querySelector('.search-toggle-mobile').addEventListener('click', () => {
+            const show = searchBar.style.display === 'none';
+            toggle_search_bar(show);
+            show_overlay(show);
+        });
+
+        // Show overlay on click for desktop
+        document.querySelector('.search-toggle-desktop').addEventListener('click', () => {
             const show = searchBar.style.display === 'none';
             toggle_search_bar(show);
             show_overlay(show);

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -345,26 +345,29 @@ export default {
         const searchBarDesktop = document.getElementById('searchBarDesktop');
 
         // Function to show/hide search bar
-        function toggle_search_bar(show_search_bar) {
+        function toggle_search_bar_mobile(show_search_bar) {
             navSearchBarMobile.style.display = show_search_bar ? 'flex' : 'none';
+
+            if (show_search_bar) {
+                searchIconMobile.classList.add('search-open');
+                searchBarMobile.focus();
+            } else {
+                searchIconMobile.classList.remove('search-open');
+            }
+        }
+
+        // Function to show/hide search bar
+        function toggle_search_bar_desktop(show_search_bar) {
             navSearchBarDesktop.style.display = show_search_bar ? 'flex' : 'none';
             productMenu.style.display = show_search_bar ? 'none' : 'flex';
 
             if (show_search_bar) {
-                searchIconMobile.classList.add('search-open');
                 searchIconDesktop.classList.add('search-open');
-
-                if (searchBarMobile.checkVisibility()) {
-                    searchBarMobile.focus();
-                } else {
-                    searchBarDesktop.focus();
-                }
+                searchBarDesktop.focus();
             } else {
-                searchIconMobile.classList.remove('search-open');
                 searchIconDesktop.classList.remove('search-open');
             }
         }
-
         // Function to show/hide overlay
         function show_overlay(overlay_visible) {
             if (overlay_visible) {
@@ -384,7 +387,7 @@ export default {
         // Close all submenus, hide overlay, and unlock scrolling when menu is closed
         function collapse_mobile_menus() {
             uncheck_menus();
-            toggle_search_bar(false);
+            toggle_search_bar_mobile(false);
             show_overlay(false);
             document.body.style.overflow = 'visible';
         }
@@ -424,24 +427,24 @@ export default {
         // Click handlers for navbar search buttons
         document.querySelector('.search-toggle-mobile').addEventListener('click', () => {
             const show = navSearchBarMobile.style.display === 'none';
-            toggle_search_bar(show);
+            toggle_search_bar_mobile(show);
             show_overlay(show);
         });
 
         document.querySelector('.search-toggle-desktop').addEventListener('click', () => {
             const show = navSearchBarDesktop.style.display === 'none';
-            toggle_search_bar(show);
+            toggle_search_bar_desktop(show);
             show_overlay(show);
         });
 
         // Click handlers for search form close buttons
         document.querySelector('.nav-search-close-mobile').addEventListener('click', () => {
-            toggle_search_bar(false);
+            toggle_search_bar_mobile(false);
             show_overlay(false);
         });
 
         document.querySelector('.nav-search-close-desktop').addEventListener('click', () => {
-            toggle_search_bar(false);
+            toggle_search_bar_desktop(false);
             show_overlay(false);
         });
 

--- a/es-vue-base/src/lib-components/EsSearchBar.vue
+++ b/es-vue-base/src/lib-components/EsSearchBar.vue
@@ -1,8 +1,9 @@
 <template>
-    <div class="align-items-center w-100 d-flex justify-content-center position-relative">
+    <div class="align-items-center w-100 d-flex flex-column flex-lg-row justify-content-center position-relative">
+        <!--  d-flex flex-column -->
         <form
             action="/search/"
-            class="d-flex align-items-center mx-auto justify-content-center w-100"
+            class="d-flex align-items-center mx-auto justify-content-center order-2 order-lg-1 w-100"
             method="get">
             <es-form-input
                 id="searchBar"
@@ -20,7 +21,7 @@
                 </template>
             </es-form-input>
             <es-button
-                class="ml-50 mb-3"
+                class="ml-50 mb-100"
                 :disabled="!searchText"
                 type="submit"
                 :value="buttonText">

--- a/es-vue-base/src/lib-components/EsSearchBar.vue
+++ b/es-vue-base/src/lib-components/EsSearchBar.vue
@@ -15,7 +15,9 @@
                 :placeholder="placeholder"
                 :value="searchText"
                 @keydown.enter="checkSearchText">
-                <template #label> Search bar </template>
+                <template #label>
+                    Search bar
+                </template>
                 <template #prefixIcon>
                     <icon-search />
                 </template>

--- a/es-vue-base/src/lib-components/EsSearchBar.vue
+++ b/es-vue-base/src/lib-components/EsSearchBar.vue
@@ -6,17 +6,15 @@
             method="get">
             <es-form-input
                 id="searchBar"
+                v-model="searchText"
                 aria-label="Search bar"
                 class="w-50"
                 label-sr-only
                 name="query"
-                v-model="searchText"
                 :placeholder="placeholder"
                 :value="searchText"
                 @keydown.enter="checkSearchText">
-                <template #label>
-                    Search bar
-                </template>
+                <template #label> Search bar </template>
                 <template #prefixIcon>
                     <icon-search />
                 </template>

--- a/es-vue-base/src/lib-components/EsSearchBar.vue
+++ b/es-vue-base/src/lib-components/EsSearchBar.vue
@@ -6,7 +6,7 @@
             class="d-flex align-items-center mx-auto justify-content-center order-2 order-lg-1 w-100"
             method="get">
             <es-form-input
-                id="searchBar"
+                :id="id"
                 v-model="searchText"
                 aria-label="Search bar"
                 class="w-50"
@@ -45,6 +45,13 @@ export default {
         EsFormInput,
     },
     props: {
+        /**
+         * A unique id to keep track of which search form is being used.
+         */
+        id: {
+            type: String,
+            required: true,
+        },
         buttonText: {
             type: String,
             default: 'Search',


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

[CED-1950: Implement mobile site search navbar](https://energysage.atlassian.net/browse/CED-1950)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Refactored mobile navbar to accommodate new search button (magnifying glass)
- Restyled mobile search form to match design in Figma
- Added an ID prop to `EsSearchBar` to prevent duplicate IDs from multiple forms on the same page
- Refactored `EsSearchBar` to accommodate mobile version without breaking current desktop version
- Restyled mobile search form
- Prevented overlay element from covering mobile search form
- Added new ID prop to `EsSearchBar` to prevent duplicate form IDs
- Adjusted mobile navbar markup to use `showSearch` prop
- Handle `searchForm.focus()` for either mobile or desktop
- Hide mobile search form when mobile menus are opened
- Hide desktop search form when desktop menus are opened

### To Do

- [x] Hide search form when mobile menus are opened
    - Attempts to resolve this have resulted in circular logic
- [ ] Close mobile menus when opening mobile search form
    - See comments below for details

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Testing locally at:
    - http://localhost:8500/organisms/es-nav-bar
    - http://localhost:8500/organisms/es-nav-bar-with-search

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- It may not be possible to use one `nav-search-bar` element for both mobile and desktop due to their locations in the navbar DOM

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
