### PR TITLE
Release 2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.5] - 2025-06-05
+
+- Use new logic for privacy button on footer
+- Updated nav and footer from storyblok
+
 ## [2.2.4] - 2025-03-07
 
 - Updated content for EsNavBar and EsFooter from Storyblok
@@ -1106,6 +1111,7 @@ the new `showPrivacySection` prop
 - Tweaks to `EsTabs` *molecule* component
 - Tweaks to `EsCollapse
 
+[2.2.5]: https://github.com/EnergySage/es-ds-legacy/compare/v2.2.4...v2.2.5
 [2.2.4]: https://github.com/EnergySage/es-ds-legacy/compare/v2.2.3...v2.2.4
 [2.2.3]: https://github.com/EnergySage/es-ds-legacy/compare/v2.2.2...v2.2.3
 [2.2.2]: https://github.com/EnergySage/es-ds-legacy/compare/v2.2.1...v2.2.2

--- a/README.md
+++ b/README.md
@@ -215,15 +215,15 @@ Assuming changes are approved, the process of publishing a new version is...
 3. `make build` - Build all packages to `*/dist` folders locally
 4. `make lint && make test` - Run tests and linting to ensure they pass
 5. Open a new branch for the release specifically
-6. Run `make publish` which will bump versions successfully but fail to commit and publish due to Jit restrictions
-7. Publish new versions of es-bs-base and/or es-vue-base by going into their folder and running `npm publish`
-8. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
-9. `make install && make symlink` - Install the new published versions locally
+6. `make publish` - Publish updated packages to
+   [npmjs.com](https://www.npmjs.com/org/energysage)
+7. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
+8. `make install && make symlink` - Install the new published versions locally
    and symlink them
-10. `git commit -m "docs: :memo: add version X.X.X to the changelog" && git push` -
-   Commit and push the changelog and `package-lock.json` updates
-11. Open a PR for this new branch and get it merged
-12. To update the v2 design system website, run the
+9. `git commit -m "docs: :memo: add version X.X.X to the changelog" && git push` -
+   Commit and push the changelog and `package-lock.json` updates to our new branch
+10. Open a PR for this new branch and get it merged
+11. To update the v2 design system website, run the
    [deploy GitHub action](https://github.com/EnergySage/es-ds-legacy/actions/workflows/deploy.yml)
 
 Running `make publish` will trigger the following prompt:

--- a/README.md
+++ b/README.md
@@ -214,14 +214,16 @@ Assuming changes are approved, the process of publishing a new version is...
    and symlink them
 3. `make build` - Build all packages to `*/dist` folders locally
 4. `make lint && make test` - Run tests and linting to ensure they pass
-5. Run `make publish` which will bump versions successfully but fail to commit and publish due to Jit restrictions
-6. Publish new versions of es-bs-base and/or es-vue-base by going into their folder and running `npm publish`
-7. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
-8. `make install && make symlink` - Install the new published versions locally
+5. Open a new branch for the release specifically
+6. Run `make publish` which will bump versions successfully but fail to commit and publish due to Jit restrictions
+7. Publish new versions of es-bs-base and/or es-vue-base by going into their folder and running `npm publish`
+8. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
+9. `make install && make symlink` - Install the new published versions locally
    and symlink them
-9. `git commit -m "docs: :memo: add version X.X.X to the changelog" && git push` -
+10. `git commit -m "docs: :memo: add version X.X.X to the changelog" && git push` -
    Commit and push the changelog and `package-lock.json` updates
-10. To update the v2 design system website, run the
+11. Open a PR for this new branch and get it merged
+12. To update the v2 design system website, run the
    [deploy GitHub action](https://github.com/EnergySage/es-ds-legacy/actions/workflows/deploy.yml)
 
 Running `make publish` will trigger the following prompt:

--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ Assuming changes are approved, the process of publishing a new version is...
    and symlink them
 3. `make build` - Build all packages to `*/dist` folders locally
 4. `make lint && make test` - Run tests and linting to ensure they pass
-5. `make publish` - Publish updated packages to
-   [npmjs.com](https://www.npmjs.com/org/energysage)
+5. Publish new versions of es-bs-base and/or es-vue-base by going into their folder and running `npm publish`
 6. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
 7. `make install && make symlink` - Install the new published versions locally
    and symlink them

--- a/README.md
+++ b/README.md
@@ -214,13 +214,14 @@ Assuming changes are approved, the process of publishing a new version is...
    and symlink them
 3. `make build` - Build all packages to `*/dist` folders locally
 4. `make lint && make test` - Run tests and linting to ensure they pass
-5. Publish new versions of es-bs-base and/or es-vue-base by going into their folder and running `npm publish`
-6. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
-7. `make install && make symlink` - Install the new published versions locally
+5. Run `make publish` which will bump versions successfully but fail to commit and publish due to Jit restrictions
+6. Publish new versions of es-bs-base and/or es-vue-base by going into their folder and running `npm publish`
+7. Update [CHANGELOG.md](./CHANGELOG.md) with our newly published changes
+8. `make install && make symlink` - Install the new published versions locally
    and symlink them
-8. `git commit -m "docs: :memo: add version X.X.X to the changelog" && git push` -
+9. `git commit -m "docs: :memo: add version X.X.X to the changelog" && git push` -
    Commit and push the changelog and `package-lock.json` updates
-9. To update the v2 design system website, run the
+10. To update the v2 design system website, run the
    [deploy GitHub action](https://github.com/EnergySage/es-ds-legacy/actions/workflows/deploy.yml)
 
 Running `make publish` will trigger the following prompt:

--- a/es-design-system/package-lock.json
+++ b/es-design-system/package-lock.json
@@ -2779,9 +2779,9 @@
             }
         },
         "node_modules/@energysage/es-vue-base": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-2.2.4.tgz",
-            "integrity": "sha512-OvQwVFJlq11xeQ1PvwGgg5nCmuZ+kyobOXa2AO01GScJ6KFBCJC7TWj8DSf+yVEZS7gJ02iqr618Opn5nhB55A==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-2.2.5.tgz",
+            "integrity": "sha512-W9cn+dtFdbcBtyVO2DRCB3lIDOSFe3xIHTtk/0tBAIx6OXjQmxNgkc205SuFdaM4YOKdzeVTJiLe5VY6v8qFNg==",
             "license": "MIT",
             "dependencies": {
                 "path": "^0.12.7",

--- a/es-design-system/package-lock.json
+++ b/es-design-system/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "es-design-system",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "es-design-system",
-            "version": "2.2.4",
+            "version": "2.2.5",
             "dependencies": {
                 "@energysage/es-bs-base": "^2.2.3",
-                "@energysage/es-vue-base": "^2.2.4",
+                "@energysage/es-vue-base": "^2.2.5",
                 "@nuxtjs/axios": "^5.13.6",
                 "@nuxtjs/i18n": "^7.3.1",
                 "bootstrap-vue": "^2.23.1",

--- a/es-design-system/package.json
+++ b/es-design-system/package.json
@@ -1,6 +1,6 @@
 {
     "name": "es-design-system",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "private": true,
     "scripts": {
         "dev": "nuxt",
@@ -18,7 +18,7 @@
     "prettier": "eslint-config-energysage/prettier",
     "dependencies": {
         "@energysage/es-bs-base": "^2.2.3",
-        "@energysage/es-vue-base": "^2.2.4",
+        "@energysage/es-vue-base": "^2.2.5",
         "@nuxtjs/axios": "^5.13.6",
         "@nuxtjs/i18n": "^7.3.1",
         "bootstrap-vue": "^2.23.1",

--- a/es-vue-base/package-lock.json
+++ b/es-vue-base/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@energysage/es-vue-base",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@energysage/es-vue-base",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
         "path": "^0.12.7",

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@energysage/es-vue-base",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": false,
   "description": "",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
         "es-vue-base",
         "es-design-system"
     ],
-    "version": "2.2.4"
+    "version": "2.2.5"
 }


### PR DESCRIPTION
Due to Jit restrictions, can no longer publish new version directly to `main`. Therefore need to run `npm publish` from each package, and also make the version bumps on a new branch. Updated docs as needed.