### PR TITLE
fix: address mismatched package lock

### DIFF
--- a/es-design-system/package-lock.json
+++ b/es-design-system/package-lock.json
@@ -2779,9 +2779,9 @@
             }
         },
         "node_modules/@energysage/es-vue-base": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-2.2.7.tgz",
-            "integrity": "sha512-RNxtoAfxP78ABSv5c+CSGtO1TJQQgkPvaR1J6NjkeKCU2rJz7Oi5YS7Tt4RtlAvKTN27g/G35mEgRYYoFOcREQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-2.3.0.tgz",
+            "integrity": "sha512-xKqPzZX1AwgYKwL+BYppcAUX4tzEQwsA9+eZ6UAq/jR8zI9Hfc+O62m0eKtg/OuZr9wwyp6h4KKbE+ZUzA6iZg==",
             "license": "MIT",
             "dependencies": {
                 "path": "^0.12.7",


### PR DESCRIPTION
Missed a step in the release process (running `make install && make symlink` after publish)