### PR TITLE
fix: add custom footer class for rip the nav

### DIFF
--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -175,6 +175,29 @@ $nav-hover-delay: 300ms;
   }
 }
 
+.social-icons-container {
+    // Use CSS gap for proper spacing that handles line wrapping correctly
+    // This automatically handles spacing between items and line endings: 24px or 1.5rem
+    gap: 24px;
+
+    // Ensure at least 2 icons per line when wrapping
+    // Use negative margin technique to force last two items to wrap together
+    a {
+        // Force the last item to "pull" the second-to-last item with it
+        &:last-child {
+            // Increased negative margin to be more aggressive about pulling
+            // Use larger value to account for icon + padding + gap: -56px or 3.5rem
+            margin-left: -56px;
+        }
+
+        // Make room for the pulled last item
+        &:nth-last-child(2) {
+            // Corresponding positive margin to make space: 56px or 3.5rem
+            margin-right: 56px;
+        }
+    }
+}
+
 .nav-es-container {
   .nav-es-global,
   .nav-es-sticky {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
https://energysage.atlassian.net/browse/CED-2178

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Add the custom footer class `social-icons-container` to `_nav.scss` so it gets pulled by the `rip-the-nav` script.
- Note: this class was copied over manually, so it is not necessary to run the rip-the-nav script after this is merged, this is just to prevent it from being wrongfully overwritten.

### 🥼 Testing

Ran the rip the nav script with this locally deployed.
`global-nav.css` was successfully updated.
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

-

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
