### PR TITLE
fix: point nav bar sign out link at accounts domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Point the nav bar "Sign out" link at the accounts domain (`{ACCOUNTS_DOMAIN}/signout/`) instead of `{ES_DOMAIN}/logout/`
+
 ## [2.4.1] - 2025-07-21
 
 - Fix use of social icons in es-site through rip-the-nav

--- a/es-vue-base/src/lib-utils/nav-bar-account-content.js
+++ b/es-vue-base/src/lib-utils/nav-bar-account-content.js
@@ -37,7 +37,7 @@ export default (
             },
             {
                 name: 'Sign out',
-                link: `${ES_DOMAIN}/logout/`,
+                link: `${ACCOUNTS_DOMAIN}/signout/`,
             },
         ],
     },

--- a/es-vue-base/src/lib-utils/nav-bar-account-content.js
+++ b/es-vue-base/src/lib-utils/nav-bar-account-content.js
@@ -36,7 +36,7 @@ export default (
                 link: `${ES_DOMAIN}/share-your-experience/`,
             },
             {
-                name: 'Sign out!',
+                name: 'Sign out',
                 link: `${ACCOUNTS_DOMAIN}/signout/`,
             },
         ],

--- a/es-vue-base/src/lib-utils/nav-bar-account-content.js
+++ b/es-vue-base/src/lib-utils/nav-bar-account-content.js
@@ -36,7 +36,7 @@ export default (
                 link: `${ES_DOMAIN}/share-your-experience/`,
             },
             {
-                name: 'Sign out',
+                name: 'Sign out!',
                 link: `${ACCOUNTS_DOMAIN}/signout/`,
             },
         ],

--- a/es-vue-base/tests/__snapshots__/EsFooter.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsFooter.spec.js.snap
@@ -160,7 +160,7 @@ exports[`EsFooter <EsFooter /> 1`] = `
         ENERGYSAGE is a registered trademark and the EnergySage logo is a trademark of EnergySage, Inc. Other trademarks are the property of either EnergySage, Inc. or our licensors and are used with permission.
       </p>
       <p class="mb-200 font-size-75">
-        © Copyright 2009-2025 EnergySage, Inc. All rights reserved.
+        © Copyright 2009-2026 EnergySage, Inc. All rights reserved.
       </p>
       <hr class="border-top border-blue-500 m-0">
       <div class="row pt-100">


### PR DESCRIPTION
## Summary

- The reasoning for this change is outlined in this comment [here](https://energysage.atlassian.net/browse/CORE-7300?focusedCommentId=92584). 
- Changes the nav bar account menu "Sign out" link from `{ES_DOMAIN}/logout/` to `{ACCOUNTS_DOMAIN}/signout/` (production: `https://accounts.energysage.com/signout/`)
- Dev environments are handled automatically via the existing `ACCOUNTS_DOMAIN` env var (same mechanism already used by the "Create an account" link), falling back to production when unset
- Refreshes the stale `EsFooter` snapshot — the footer renders the current copyright year, so the 2025-era snapshot fails for everyone in 2026

## Ticket

https://energysage.atlassian.net/browse/CORE-7300

## Testing

By Claude- 
- `npm run test` in `es-vue-base`: 371/371 passing
- `npm run lint` in `es-vue-base`: clean
- Verified no other references to the old `/logout/` URL remain in the repo

By me - 
- Manual testing to confirm that the signout link is updated in the DOM 
<img width="971" height="580" alt="Screenshot 2026-06-12 at 10 31 51 AM" src="https://github.com/user-attachments/assets/7f2e8f2a-93fc-4455-9dff-55f2c1ca6a96" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)